### PR TITLE
feat: add support for DatoCMS environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ datocms_api_key = Application.fetch_env!(:my_app, :api_key)
 DatoCMS.GraphQLClient.configure(api_key: datocms_api_key)
 ```
 
+# Environments
+If you've multiple DatoCMS environment you can control which one we'll fetch data from by using the :environment keyword.
+Example:
+```elixir
+datocms_api_key = Application.fetch_env!(:my_app, :api_key)
+DatoCMS.GraphQLClient.configure(api_key: datocms_api_key, environment: "stage")
+```
+
 # Queries
 
 * single items: `DatoCMS.GraphQLClient.fetch!(:foo, "{ bar }").bar`,

--- a/lib/datocms/graphql_client/backends/standard_client.ex
+++ b/lib/datocms/graphql_client/backends/standard_client.ex
@@ -19,6 +19,12 @@ defmodule DatoCMS.GraphQLClient.Backends.StandardClient do
       Neuron.Config.set(headers: [authorization: "Bearer #{api_key}"])
     end
 
+    if Keyword.has_key?(config, :environment) do
+      headers = Neuron.Config.get(:headers)
+      environment = config[:environment]
+      Neuron.Config.set(headers: headers ++ ["X-Environment": "#{environment}"])
+    end
+
     Neuron.Config.set(connection_opts: [timeout: :infinity, recv_timeout: :infinity])
     Neuron.Config.set(parse_options: [keys: :atoms])
   end


### PR DESCRIPTION
This feature opens up support for having multiple DatoCMS environments, as that could be useful when for exampling having a stage-environment.